### PR TITLE
Correct path to SMART test flight file

### DIFF
--- a/HALO-AC3/HALO/smart.yaml
+++ b/HALO-AC3/HALO/smart.yaml
@@ -13,7 +13,7 @@ sources:
   HALO-AC3_HALO_RF00:
     driver: netcdf
     args:
-      urlpath: simplecache::https://{{user}}:{{password}}@cloud.ac3-tr.de/remote.php/webdav/halo-ac3/halo/SMART/HALO-AC3_HALO_SMART_spectral_irradiance_Fdw_ql_20220311_RF01.nc
+      urlpath: simplecache::https://{{user}}:{{password}}@cloud.ac3-tr.de/remote.php/webdav/halo-ac3/halo/SMART/HALO-AC3_HALO_SMART_spectral_irradiance_Fdw_ql_20220225_RF00.nc
   HALO-AC3_HALO_RF01:
     driver: netcdf
     args:


### PR DESCRIPTION
Just a simple correction of the path to one SMART quicklook file.